### PR TITLE
Fix "Unexpected end of JSON input" error when fetching `v1/models`

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -45,10 +45,12 @@ async function proxy(request, env) {
   // 2. replace with the real API key
   headers.set(authKey, `Bearer ${env.OPENAPI_API_KEY}`);
   // 3. issue the underlying request
+  // Only pass body if request method is not 'GET'
+  const requestBody = request.method !== 'GET' ? JSON.stringify(await request.json()) : null;
   return fetch(url, {
     method: request.method,
     headers: headers,
-    body: JSON.stringify(await request.json()),
+    body: requestBody,
   });
 }
 


### PR DESCRIPTION
## Motivation

This PR addresses the issue encountered when using apps like OpenCat, which make GET requests to the endpoint `v1/models` for API key validation. Previously, the existing code would throw an "Unexpected end of JSON input" error.

The potential cause of this issue was that the `body` parameter was being passed with the `fetch` function even in GET requests. According to the `fetch` API, GET requests should not contain a `body`.

To fix the issue, the following changes were made in the `proxy` function:

```javascript
// Only pass body if request method is not 'GET'
const requestBody = request.method !== 'GET' ? JSON.stringify(await request.json()) : null;

return fetch(url, {
    method: request.method,
    headers: headers,
    body: requestBody,
});
```

This modification first checks if the request method is GET. If it is, `requestBody` is set to `null`. Consequently, when calling the `fetch` function, the `body` parameter is not included in the GET request, effectively preventing the "Unexpected end of JSON input" error from occurring.

